### PR TITLE
chore: export directmessage type

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -3,7 +3,7 @@ export type JsonObject = { [member: string]: JsonSerializable }
 export type JsonArray = JsonSerializable[]
 export type JsonSerializable = JsonPrimitive | JsonObject | JsonArray
 
-export interface MessageDirect<T = JsonSerializable> {
+export interface DirectMessage<T = JsonSerializable> {
   from: string
   to: string
   data: T

--- a/src/direct.ts
+++ b/src/direct.ts
@@ -3,11 +3,11 @@ import PeerId from 'peer-id'
 import pipe from 'it-pipe'
 import Emittery from 'emittery'
 
-import type { JsonSerializable, Dictionary, MessageDirect } from './definitions'
+import type { JsonSerializable, Dictionary, DirectMessage } from './definitions'
 
 export const PROTOCOL = 'rif-communications-pubsub/v0.1.0'
 
-export default class DirectChat extends Emittery.Typed<{ 'message': MessageDirect, 'error': Error }> {
+export default class DirectChat extends Emittery.Typed<{ 'message': DirectMessage, 'error': Error }> {
   // Dictionary of libp2p listeners
   private static protocols: Dictionary<DirectChat> = {}
   private libp2p: Libp2p
@@ -54,7 +54,7 @@ export default class DirectChat extends Emittery.Typed<{ 'message': MessageDirec
           try {
             const parsedData = JSON.parse(Buffer.from(msg.data, 'hex').toString()) as JsonSerializable
 
-            const m: MessageDirect = {
+            const m: DirectMessage = {
               from: msg.from,
               to: msg.to,
               data: parsedData

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ import DirectChat, { PROTOCOL } from './direct'
 import createLibP2P from './libp2p/nodejs'
 
 export { Room, DirectChat, createLibP2P, PROTOCOL }
-export type { Message, JsonSerializable, Options } from './definitions'
+export type { Message, JsonSerializable, Options, DirectMessage } from './definitions'


### PR DESCRIPTION
BREAKING CHANGE: Rename of MessageDirect interface to DirectMessage